### PR TITLE
Compatibility with modern hubot

### DIFF
--- a/src/kandan.coffee
+++ b/src/kandan.coffee
@@ -30,8 +30,7 @@ class Kandan extends Adapter
     @bot = new KandanStreaming(options, @robot)
 
     @bot.on "TextMessage", (message) ->
-      unless message.user_id == 4
-        self.receive new TextMessage(message.user.email, message.content)
+      self.receive new TextMessage(message.user.email, message.content)
 
     self.emit "connected"
 


### PR DESCRIPTION
This PR consists of changes to make the Kandan adapter operate with modern Hubots.

Additionally, it removes a hard-coded ID test that makes the bot deaf to whichever user is unlucky enough to have received ID 4.
