### PR TITLE
Don't need channel_id in activity body, and causes mass-assignment error in kandan

### DIFF
--- a/src/kandan.coffee
+++ b/src/kandan.coffee
@@ -125,7 +125,6 @@ class KandanStreaming extends EventEmitter
       channel_id: channelId
       activity: {
         content: message,
-        channel_id: channelId,
         action: "message"
       }
     }


### PR DESCRIPTION
Our Hubot was broken after we updated kandan. The kanan activities controller now scopes activities automatically to the channel id directly from the channel_id parameter. So the nested activity[:channel_id] parameter is no longer needed, and actually causes a mass-assignment error, causing hubot's post to fail.
