### PR TITLE
Fix npm error when booting hubot

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git clone git@github.com:kandanapp/hubot-kandan.git node_modules/hubot-kandan
 npm install faye
 ```	
 
-* Add `"hubot-kandan": "1.0"` as a dependency in your hubots `package.json`
+* Add `"hubot-kandan": "1.0.0"` as a dependency in your hubots `package.json`
 * Remove `"redis-brain.coffee",` from hubot-scripts.json 
 
 You will need to set a few environment variables in order for it to work properly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":        "hubot-kandan",
-  "version":     "1.0",
+  "version":     "1.0.0",
   "author":      "kandan",
   "keywords":    "github hubot kandan adapter",
   "description": "A Kandan adapter for Hubot",


### PR DESCRIPTION
Npm raised an error when executing README.md's install instraction.

```
$ hubot -a kandan
npm ERR! Darwin 14.0.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.10.33
npm ERR! npm  v2.1.6
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: hubot-kandan@'>=1.0.0 <1.1.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.9.0","0.9.1","0.9.2","0.9.3","0.9.4","0.9.5","0.9.6"]
npm ERR! notarget
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/yuuki/docker/hubot/npm-debug.log
bin/hubot: line 6: /Users/yuuki/docker/hubot/node_modules/.bin/hubot: No such file or 
```

It is caused by validation of semantic versioning.
