### PR TITLE
Fix missing ntwitter module in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install
 make package
 cd hubot
 git clone git@github.com:kandanapp/hubot-kandan.git node_modules/hubot-kandan
-npm install faye
+npm install faye ntwitter
 ```	
 
 * Add `"hubot-kandan": "1.0"` as a dependency in your hubots `package.json`


### PR DESCRIPTION
Hubot raised an error when executing README.md's install instraction.

```
$ hubot -a kandan
npm WARN package.json optparse@1.0.3 No repository field.
...
[Fri Nov 07 2014 23:16:48 GMT+0900 (JST)] ERROR Unable to load /Users/yuuki/docker/hubot/node_modules/hubot-scripts/src/scripts/tweet: Error: Cannot find module 'ntwitter'
```

It is caused by missing dependancy for ntwitter.
