### PR TITLE
fix room reference

### DIFF
--- a/src/kandan.coffee
+++ b/src/kandan.coffee
@@ -19,10 +19,10 @@ Faye         = require('faye')
 
 class Kandan extends Adapter
 
-  send: (user, strings...) ->
+  send: (envelope, strings...) ->
     if strings.length > 0
-      callback = errback = (response) => @send user, strings...
-      @bot.message strings.shift(), user?.room?.id || 1, callback, errback
+      callback = errback = (response) => @send envelope, strings...
+      @bot.message strings.shift(), envelope.room || 1, callback, errback
 
   run: ->
     options =
@@ -34,8 +34,10 @@ class Kandan extends Adapter
     callback = (myself) =>
       @bot.on "TextMessage", (message) =>
         unless myself.id == message.user.id
-          message.user.room = message.channel
-          @receive new TextMessage(message.user, message.content)
+          envelope =
+            user: message.user.id
+            room: message.channel.id
+          @receive new TextMessage(envelope, message.content)
       @emit "connected"
     errback = (response) =>
       throw new Error "Unable to determine profile information."


### PR DESCRIPTION
It fixes a problem that it ignore a room number from another script.
It is because hubot use envelope.room to identify channel as standard,
but hubot-kandan use envelope.room.id for it.

A room number originated from other scripts or hubot itself
is ignored and always set default '1'.

A root cause was;
'envelop' is introduced in hubot commit dc27aca6fcbd0
in 12 Jan 2013.
But hubot-kandan put name 'user' for it as same as kandan.

There are room.id and user.id in kandan, and is difference with hubot.
This commit aims to use as same termnology as hubot.

envelope.user - The User
envelope.room - The room identifier

Signed-off-by: Hiroshi Miura miurahr@linux.com
